### PR TITLE
Extract: return polygon IDs to output

### DIFF
--- a/R/velox_extract.R
+++ b/R/velox_extract.R
@@ -47,11 +47,15 @@ VeloxRaster$methods(extract = function(sp, fun = NULL) {
     return(out)
   }
 
+  sp_IDs <- sapply(sp@polygons, function(x) slot(x, "ID"))
   if (!is.null(fun)) {
     out <- matrix(NA, length(sp), nbands)
+    rownames(out) <- sp_IDs
   } else {
     out <- vector("list", length(sp))
+    names(out) <- sp_IDs
   }
+  
 
 
   for (p in 1:length(sp)) {

--- a/tests/testthat/test_extract.R
+++ b/tests/testthat/test_extract.R
@@ -23,6 +23,7 @@ test_that("summary extract works", {
   vx.emat <- vx$extract(sp=spols, fun = mean)
   rs.emat <- extract(x = brk, y = spols, fun = mean)
   colnames(vx.emat) <- colnames(rs.emat)
+  rownames(vx.emat) <- rownames(rs.emat)
 
   ## Comparison
   expect_equal(vx.emat, rs.emat)
@@ -48,7 +49,7 @@ test_that("raw extract works", {
   rs.elist <- extract(x = brk, y = spols, fun = NULL)
 
   ## Comparison
-  expect_true(all(vx.elist[[1]][,1] %in% rs.elist[[1]][,1]))
+    expect_true(all(vx.elist[[1]][,1] %in% rs.elist[[1]][,1]))
   expect_true(all(vx.elist[[1]][,2] %in% rs.elist[[1]][,2]))
   expect_true(all(vx.elist[[2]][,1] %in% rs.elist[[2]][,1]))
   expect_true(all(vx.elist[[2]][,2] %in% rs.elist[[2]][,2]))


### PR DESCRIPTION
extract: add original polygon IDs to the output, either as rownames (fun is not null) or names (fun is null)