### PR TITLE
Add argument df=TRUE to extract

### DIFF
--- a/R/velox_extract.R
+++ b/R/velox_extract.R
@@ -12,6 +12,8 @@
 #'
 #' @param sp A SpatialPolygons* object.
 #' @param fun An R function. See Details.
+#' @param df Wether result should be passed as a data-frame (df=TRUE) or matrix (default: FALSE). If true, will return a 
+#' column \code{ID_sp} containing the ID of the sp object. 
 #'
 #' @return
 #' If \code{fun} is passed: A numeric matrix with one row per element in \code{sp}, one column per band in the VeloxRaster.
@@ -38,7 +40,7 @@
 #' @import rgeos
 #' @import sp
 NULL
-VeloxRaster$methods(extract = function(sp, fun = NULL) {
+VeloxRaster$methods(extract = function(sp, fun = NULL, df=FALSE) {
   "See \\code{\\link{VeloxRaster_extract}}."
 
   overlaps <- .self$overlapsExtent(sp)
@@ -117,6 +119,16 @@ VeloxRaster$methods(extract = function(sp, fun = NULL) {
       }
     }
 
+  }
+  
+  if(df){
+    if(!is.null(fun)) {
+      out <- data.frame(ID_sp=sp_IDs, out)
+    } else {
+      nrow_each <- sapply(out, function(x) {nr <- nrow(x); if(is.null(nr)) 0 else nr})
+      sp_IDs_rep <- unlist(Map(rep, sp_IDs, nrow_each))
+      out <- data.frame(ID_sp=sp_IDs_rep, do.call("rbind", out))
+    }
   }
   return(out)
 })

--- a/tests/testthat/test_extract.R
+++ b/tests/testthat/test_extract.R
@@ -67,23 +67,23 @@ test_that("both extract work with df=TRUE", {
               crs="+proj=longlat +datum=WGS84 +no_defs")
   
   ## Make SpatialPolygons
-  coord <- matrix(c(0,0,1,1), 2, 2, byrow = TRUE)
+  coord <- matrix(c(0,0,1,1, 0.5, 0.55), nrow=3, 2, byrow = TRUE)
   spoint <- SpatialPoints(coords=coord)
-  spols <- gBuffer(spgeom=spoint, width=0.5, byid = TRUE)
+  spols <- gBuffer(spgeom=spoint, width=c(0.5, 0.5, 0.04), byid = TRUE)
   
   ## Extract raw values as data-frame
   vx.raw.df <- vx$extract(sp=spols, fun = NULL, df=TRUE)
-  rs.raw.df <- extract(x = brk, y = spols, fun = NULL, df=TRUE)
+  rs.raw.df <- extract(x = brk, y = spols, fun = NULL, df=TRUE, small=FALSE)
   dimnames(rs.raw.df) <- dimnames(vx.raw.df)
 
   ## Extract aggregated values as data-frame
   vx.foo.df <- vx$extract(sp=spols, fun = mean, df=TRUE)
-  rs.foo.df <- extract(x = brk, y = spols, fun = mean, df=TRUE)
+  rs.foo.df <- extract(x = brk, y = spols, fun = mean, df=TRUE, small=FALSE)
   dimnames(rs.foo.df) <- dimnames(vx.foo.df)
   
   ## Comparison
   expect_true(all(vx.raw.df == rs.raw.df))
-  expect_true(all(vx.foo.df == rs.foo.df))
+  expect_true(all(vx.foo.df == rs.foo.df| is.na(vx.foo.df)==is.na(rs.foo.df)))
 })
 
 test_that("raw extract works if polygon too small to intersect", {

--- a/tests/testthat/test_extract.R
+++ b/tests/testthat/test_extract.R
@@ -49,11 +49,41 @@ test_that("raw extract works", {
   rs.elist <- extract(x = brk, y = spols, fun = NULL)
 
   ## Comparison
-    expect_true(all(vx.elist[[1]][,1] %in% rs.elist[[1]][,1]))
+  expect_true(all(vx.elist[[1]][,1] %in% rs.elist[[1]][,1]))
   expect_true(all(vx.elist[[1]][,2] %in% rs.elist[[1]][,2]))
   expect_true(all(vx.elist[[2]][,1] %in% rs.elist[[2]][,1]))
   expect_true(all(vx.elist[[2]][,2] %in% rs.elist[[2]][,2]))
 
+})
+
+test_that("both extract work with df=TRUE", {
+  
+  ## Make VeloxRaster with two bands
+  set.seed(0)
+  mat1 <- matrix(rnorm(100), 10, 10)
+  mat2 <- matrix(rnorm(100), 10, 10)
+  brk <- brick(raster(mat1), raster(mat2))
+  vx <- velox(list(mat1, mat2), extent=c(0,1,0,1), res=c(0.1,0.1),
+              crs="+proj=longlat +datum=WGS84 +no_defs")
+  
+  ## Make SpatialPolygons
+  coord <- matrix(c(0,0,1,1), 2, 2, byrow = TRUE)
+  spoint <- SpatialPoints(coords=coord)
+  spols <- gBuffer(spgeom=spoint, width=0.5, byid = TRUE)
+  
+  ## Extract raw values as data-frame
+  vx.raw.df <- vx$extract(sp=spols, fun = NULL, df=TRUE)
+  rs.raw.df <- extract(x = brk, y = spols, fun = NULL, df=TRUE)
+  dimnames(rs.raw.df) <- dimnames(vx.raw.df)
+
+  ## Extract aggregated values as data-frame
+  vx.foo.df <- vx$extract(sp=spols, fun = mean, df=TRUE)
+  rs.foo.df <- extract(x = brk, y = spols, fun = mean, df=TRUE)
+  dimnames(rs.foo.df) <- dimnames(vx.foo.df)
+  
+  ## Comparison
+  expect_true(all(vx.raw.df == rs.raw.df))
+  expect_true(all(vx.foo.df == rs.foo.df))
 })
 
 test_that("raw extract works if polygon too small to intersect", {


### PR DESCRIPTION
Adding an argument df=TRUE to extract, both for raw data and aggregated (using fun) one. Output is similar to that of raster::extract. Differences include:

1. With non-overlapping polygons (i.e. polygons whose center does not fall into a cell), raster::extract uses cells around, if `small=TRUE`. So comparison with raster should be made with `small=FALSE`

2. Column name: I named the polygons `ID_sp`, while raster has `ID`. I remember being confused when using raster which was the raster and the polygon ID, so something more explicit like `ID_sp` seems clearer. But for consistency reason, you might well choose to use the same. 

3. Content of the `ID_sp` column: here returns the polygon ID, not number. In the test, ID is number so don't see the difference, but in other cases difference would show up. Not sure how much this polygon ID is general to shp files, or specific to the sp implementation? I think for example in sf this is not the case anymore?

Please check also what I added in help file, might surely be improved. 